### PR TITLE
services/slb/selectors/round_robing.go:Added round robin selector

### DIFF
--- a/services/slb/selectors/roundRobin/round_robin.go
+++ b/services/slb/selectors/roundRobin/round_robin.go
@@ -1,0 +1,64 @@
+package roundRobin
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// RoundRobin Selects targets sequentially (in a structured order)
+type RoundRobin struct {
+	mu        *sync.Mutex
+	endpoints []*http.Server
+	currIdx   int
+}
+
+func New() *RoundRobin {
+	return &RoundRobin{endpoints: make([]*http.Server, 0), currIdx: 0, mu: &sync.Mutex{}}
+}
+
+func (r *RoundRobin) Select() (*http.Server, error) {
+	endpoints, err := r.EndPoints()
+	if err != nil {
+		return nil, err
+	}
+	if len(endpoints) <= 0 {
+		return nil, fmt.Errorf("selector has no endpoints to select")
+	}
+	if r.currIdx == len(endpoints)-1 {
+		r.currIdx = 0
+	}
+	r.currIdx++
+	return endpoints[r.currIdx], nil
+}
+
+func (r *RoundRobin) EndPoints() ([]*http.Server, error) {
+	return r.endpoints, nil
+}
+
+func (r *RoundRobin) Add(server *http.Server) error {
+	defer r.mu.Unlock()
+	r.mu.Lock()
+	r.endpoints = append(r.endpoints, server)
+	return nil
+}
+
+func (r *RoundRobin) Remove(server *http.Server) error {
+	defer r.mu.Unlock()
+	r.mu.Lock()
+	if found, idx := r.findInPool(server, r.endpoints); found {
+		r.endpoints = append(r.endpoints[:idx], r.endpoints[idx+1:]...)
+		return nil
+	}
+	return fmt.Errorf("could not find server to delete %+v", server)
+}
+
+func (r *RoundRobin) findInPool(server *http.Server, endpoints []*http.Server) (bool, int) {
+	found := false
+	for i, s := range endpoints {
+		if s == server {
+			return true, i
+		}
+	}
+	return found, -1
+}

--- a/services/slb/selectors/roundRobin/round_robin_test.go
+++ b/services/slb/selectors/roundRobin/round_robin_test.go
@@ -1,0 +1,46 @@
+package roundRobin
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"balance/pkg/mock"
+)
+
+type RRTest struct {
+	name        string
+	t           *testing.T
+	endpoints   []*http.Server
+	nSelections int
+	toSelect    *http.Server
+}
+
+func (r *RRTest) Run() {
+	selector := New()
+	for _, e := range r.endpoints {
+		require.NoError(r.t, selector.Add(e))
+	}
+	var err error
+	var selected *http.Server
+	for nSelection := 0; nSelection < r.nSelections; nSelection++ {
+		selected, err = selector.Select()
+		require.NoError(r.t, err)
+	}
+	if r.toSelect != nil {
+		require.Exactly(r.t, selected, r.toSelect)
+	}
+}
+
+func TestRoundRobin(t *testing.T) {
+	scenarios := []*RRTest{}
+	servers := mock.GenerateServers(3)
+	scenarioWithinRange := &RRTest{"test selection within endpoint range", t, servers, 1, servers[1]}
+	scenarioOutSideRange := &RRTest{"selection outside of endpoint range", t, servers, 5, servers[1]}
+
+	scenarios = append(scenarios, scenarioWithinRange, scenarioOutSideRange)
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) { scenario.Run() })
+	}
+}


### PR DESCRIPTION
Round Robin cyclicly selects servers from the backend pool.

Issue: #3