### PR TITLE
services/slb/slb.go:fix always logging error

### DIFF
--- a/services/slb/slb.go
+++ b/services/slb/slb.go
@@ -83,7 +83,9 @@ func (s *Slb) Run() error {
 	slog.Info("SLB started at: " + s.server.Addr + ":" + s.cfg.Postfix())
 
 	err := s.server.ListenAndServe()
-	slog.Error(err.Error())
+	if err != nil {
+		slog.Error(err.Error())
+	}
 	return err
 }
 


### PR DESCRIPTION
The slb was always logging an error, even if none had occured. This changes to logging only on error occurance.