### PR TITLE
services/slb/selectors/roundRobin:Fix omit first & last endpoint

### DIFF
--- a/services/slb/selectors/roundRobin/round_robin.go
+++ b/services/slb/selectors/roundRobin/round_robin.go
@@ -18,6 +18,7 @@ func New() *RoundRobin {
 }
 
 func (r *RoundRobin) Select() (*http.Server, error) {
+
 	endpoints, err := r.EndPoints()
 	if err != nil {
 		return nil, err
@@ -25,10 +26,17 @@ func (r *RoundRobin) Select() (*http.Server, error) {
 	if len(endpoints) <= 0 {
 		return nil, fmt.Errorf("selector has no endpoints to select")
 	}
-	if r.currIdx == len(endpoints)-1 {
-		r.currIdx = 0
-	}
-	r.currIdx++
+
+	// manage index within defer to avoid index change at access
+	defer func([]*http.Server) {
+
+		if r.currIdx >= len(r.endpoints)-1 {
+			r.currIdx = 0 // reset index
+		} else {
+			r.currIdx++
+		}
+	}(endpoints)
+
 	return endpoints[r.currIdx], nil
 }
 

--- a/services/slb/selectors/roundRobin/round_robin_test.go
+++ b/services/slb/selectors/roundRobin/round_robin_test.go
@@ -24,7 +24,7 @@ func (r *RRTest) Run() {
 	}
 	var err error
 	var selected *http.Server
-	for nSelection := 0; nSelection < r.nSelections; nSelection++ {
+	for nSelection := 1; nSelection <= r.nSelections; nSelection++ {
 		selected, err = selector.Select()
 		require.NoError(r.t, err)
 	}
@@ -36,7 +36,7 @@ func (r *RRTest) Run() {
 func TestRoundRobin(t *testing.T) {
 	scenarios := []*RRTest{}
 	servers := mock.GenerateServers(3)
-	scenarioWithinRange := &RRTest{"test selection within endpoint range", t, servers, 1, servers[1]}
+	scenarioWithinRange := &RRTest{"test selection within endpoint range", t, servers, 1, servers[0]}
 	scenarioOutSideRange := &RRTest{"selection outside of endpoint range", t, servers, 5, servers[1]}
 
 	scenarios = append(scenarios, scenarioWithinRange, scenarioOutSideRange)


### PR DESCRIPTION
The selector of the round robin nlb would change the index before accessing the endpoint list, which would cause it to skip the first endpoint.
Due to the above the index would reach len-1 prematurely, and reset the index to early.

With the fix the index is changed only in defer, which means post accessing the endpoint it needs to access. It will only be increased if not reset and vice versa.