### PR TITLE
Makefile: test-integration - fix prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ gen:
     # make slb api 
 	go generate ./...
 
-test-integration:
-	gen
+test-integration: gen
 	go test ./... -tags="integration"
 
 # at this point only clean generated code and the final build dockers


### PR DESCRIPTION
The 'make gen' command was not properly configured, calling gen instead of it being set as a prerequisite for test-integration.