### PR TITLE
Security: Add mTLS to API service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 **.git/
 **.tar.gz
 **test.go
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist/*
 # Generated files
 **/gen/*
 
+# Files created by test execution
+tmp/
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,19 @@ A Simple and Effective Go Software Load Balancer
 
 # Usage
 Balance is built as a simple to use Load Balancer that disperses Requests to the server on which it runs as a proxy to the servers provided in its configuration.
-Balance can be used as binary packed in a docker, or used directly from your code utilizing [`services/slb`](#Services/slb).
-It itself runs a Grpc server to control and configure the load balancer (see api reference ./services/slb/api.proto)
+
+Balance can be used as binary packed in a docker,
+
+## Slb Package
+Balance can be used directly from your code utilizing [`services/slb`](#Services/slb).
+In this case you can incorporate the slb directly in your code, if you do not prefer running it as a separate service.
+
+## Balance Service
+The balance service itself runs a Grpc server to control and configure the load balancer (see api reference ./services/slb/api.proto)
+
+#### Security
+The balance service requires mTLS to access the SLBs API, to configure and use it.
+In order to use the service, you must create the ca, key, and certificate on the machine or container running the service.
 
 # Services/slb
 The Slb can be used as a handler on instances of http.Server
@@ -34,3 +45,4 @@ FrontendServeHTTP --> Selector --> select --> serve -->|send to backend| Backend
 ## Docker
 To build the Docker image run
 ```make balance-docker```
+- Security: Add mTLS certificates to the container before running with its defaul entry point.

--- a/docker/Dockerfile.balance
+++ b/docker/Dockerfile.balance
@@ -5,6 +5,8 @@ COPY --from=builder /app/balance .
 
 # Ensure the binary is executable
 RUN chmod +x balance
+# certs directory: Please note that certificates are not provided and need to be added to the container and the api client.
+RUN mkdir -p /etc/certs
 
 ENTRYPOINT ["./balance"]
 

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -10,20 +10,17 @@ import (
 
 	api "balance/gen"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-const testNamePrefix = "grpc-sanity"
-
 func TestGRPCSanityNotConfigured(t *testing.T) {
-	_, _, containerID := setup(t, testNamePrefix+"-"+uuid.NewString()[:4])
+	_, _, containerID, certDir := setup(t)
 	require.NotEmpty(t, containerID)
 
 	ip, err := getContainerIP(containerID)
 	require.NoError(t, err)
-	apiClient, err := newApiClient(ip, HostPort)
+	apiClient, err := newApiClient(certDir, ip, HostPort)
 	require.NoError(t, err)
 
 	apiCtx, cancelFunc := context.WithTimeout(context.Background(), time.Second*1)
@@ -33,12 +30,12 @@ func TestGRPCSanityNotConfigured(t *testing.T) {
 }
 
 func TestGrpcConfigureNegativeNoEndpoints(t *testing.T) {
-	_, _, containerID := setup(t, testNamePrefix+"-"+uuid.NewString()[:4])
+	_, _, containerID, certDir := setup(t)
 	require.NotEmpty(t, containerID)
 
 	ip, err := getContainerIP(containerID)
 	require.NoError(t, err)
-	apiClient, err := newApiClient(ip, HostPort)
+	apiClient, err := newApiClient(certDir, ip, HostPort)
 	require.NoError(t, err)
 
 	config := &api.Config{}
@@ -50,12 +47,12 @@ func TestGrpcConfigureNegativeNoEndpoints(t *testing.T) {
 }
 
 func TestGrpcConfigureNegativeEndpoints(t *testing.T) {
-	_, _, containerID := setup(t, testNamePrefix+"-"+uuid.NewString()[:4])
+	_, _, containerID, certDir := setup(t)
 	require.NotEmpty(t, containerID)
 
 	ip, err := getContainerIP(containerID)
 	require.NoError(t, err)
-	apiClient, err := newApiClient(ip, HostPort)
+	apiClient, err := newApiClient(certDir, ip, HostPort)
 	require.NoError(t, err)
 
 	endpoints := []*api.Server{{Address: " ="}}
@@ -68,12 +65,12 @@ func TestGrpcConfigureNegativeEndpoints(t *testing.T) {
 }
 
 func TestGrpcConfigureEndpoints(t *testing.T) {
-	_, _, containerID := setup(t, testNamePrefix+"-"+uuid.NewString()[:4])
+	_, _, containerID, certDir := setup(t)
 	require.NotEmpty(t, containerID)
 
 	ip, err := getContainerIP(containerID)
 	require.NoError(t, err)
-	apiClient, err := newApiClient(ip, HostPort)
+	apiClient, err := newApiClient(certDir, ip, HostPort)
 	require.NoError(t, err)
 
 	// setting this endpoint so the slb itself will be an endpoint asm this address refers to all of its nics
@@ -87,12 +84,12 @@ func TestGrpcConfigureEndpoints(t *testing.T) {
 }
 
 func TestGrpcConfigureRunStopNoLoad(t *testing.T) {
-	_, _, containerID := setup(t, testNamePrefix+"-"+uuid.NewString()[:4])
+	_, _, containerID, certDir := setup(t)
 	require.NotEmpty(t, containerID)
 
 	ip, err := getContainerIP(containerID)
 	require.NoError(t, err)
-	apiClient, err := newApiClient(ip, HostPort)
+	apiClient, err := newApiClient(certDir, ip, HostPort)
 	require.NoError(t, err)
 	endpoints := []*api.Server{{Address: "0.0.0.0"}}
 	config := &api.Config{Endpoints: endpoints}

--- a/tests/integration/docker_harness.go
+++ b/tests/integration/docker_harness.go
@@ -12,14 +12,10 @@ import (
 	"log/slog"
 	"time"
 
-	apiService "balance/services/api_service"
-	backendServer "balance/tests/integration/mock/backend/server"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
 )
 
 const (
@@ -35,25 +31,8 @@ func createDockerClient() (*client.Client, error) {
 	return client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 }
 
-
-func createContainer(ctx context.Context, cli *client.Client, config *container.Config, containerName string) (string, error) {
+func createContainer(ctx context.Context, cli *client.Client, config *container.Config, hostConfig *container.HostConfig, containerName string) (string, error) {
 	// Create host configuration with port mapping
-	hostConfig := &container.HostConfig{
-		PortBindings: nat.PortMap{
-			apiService.DefaultApiPort + "/tcp": []nat.PortBinding{
-				{
-					HostIP:   "0.0.0.0",
-					HostPort: HostPort,
-				},
-			},
-			"8080/tcp": []nat.PortBinding{
-				{
-					HostIP:   "0.0.0.0",
-					HostPort: backendServer.ListenPort,
-				},
-			},
-		},
-	}
 	resp, err := cli.ContainerCreate(ctx, config, hostConfig, nil, nil, containerName)
 	if err != nil {
 		return "", fmt.Errorf("error creating Docker container: %v", err)

--- a/tests/integration/docker_harness.go
+++ b/tests/integration/docker_harness.go
@@ -40,7 +40,7 @@ const (
 	backendListenPort = "8080"
 )
 
-func createAndStartContainer(ctx context.Context, cli *client.Client, config *container.Config, containerName string) (string, error) {
+func createContainer(ctx context.Context, cli *client.Client, config *container.Config, containerName string) (string, error) {
 	// Create host configuration with port mapping
 	hostConfig := &container.HostConfig{
 		PortBindings: nat.PortMap{
@@ -62,13 +62,14 @@ func createAndStartContainer(ctx context.Context, cli *client.Client, config *co
 	if err != nil {
 		return "", fmt.Errorf("error creating Docker container: %v", err)
 	}
+	return resp.ID, nil
+}
 
-	containerID := resp.ID
+func startContainer(cli *client.Client, ctx context.Context, containerID string) error {
 	if err := cli.ContainerStart(ctx, containerID, types.ContainerStartOptions{}); err != nil {
-		return "", fmt.Errorf("error starting Docker container: %v", err)
+		return fmt.Errorf("error starting Docker container: %v", err)
 	}
-
-	return containerID, nil
+	return nil
 }
 
 func stopContainer(ctx context.Context, cli *client.Client, containerID string) error {

--- a/tests/integration/docker_harness.go
+++ b/tests/integration/docker_harness.go
@@ -35,10 +35,6 @@ func createDockerClient() (*client.Client, error) {
 	return client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 }
 
-const (
-	HostPort          = apiService.DefaultApiPort
-	backendListenPort = "8080"
-)
 
 func createContainer(ctx context.Context, cli *client.Client, config *container.Config, containerName string) (string, error) {
 	// Create host configuration with port mapping

--- a/tests/integration/docker_harness_test.go
+++ b/tests/integration/docker_harness_test.go
@@ -28,9 +28,10 @@ func TestSLBDockerStartSanity(t *testing.T) {
 	config := &container.Config{
 		Image: imageTags[0],
 	}
-	containerID, err := createAndStartContainer(ctx, cli, config, strings.ToLower(t.Name()+"-"+uuid.NewString()[:4]))
+	containerID, err := createContainer(ctx, cli, config, strings.ToLower(t.Name()+"-"+uuid.NewString()[:4]))
 	require.NoError(t, err)
 	t.Cleanup(func() { cleanupContainer(context.Background(), cli, containerID) })
+	require.NoError(t, startContainer(cli, ctx, containerID))
 
 	output, err := getContainerLogs(ctx, cli, containerID)
 	t.Log(output)
@@ -50,7 +51,8 @@ func TestSLBDockerCreateFailedBadImageName(t *testing.T) {
 			"5001":                    struct{}{},
 		},
 	}
-	id, err := createAndStartContainer(context.Background(), cli, config, strings.ToLower(t.Name()))
+	id, err := createContainer(context.Background(), cli, config, strings.ToLower(t.Name()))
+	t.Cleanup(func() { cleanupContainer(context.Background(), cli, id) })
 	require.Error(t, err)
 	require.Empty(t, id)
 }

--- a/tests/integration/docker_harness_test.go
+++ b/tests/integration/docker_harness_test.go
@@ -28,7 +28,7 @@ func TestSLBDockerStartSanity(t *testing.T) {
 	config := &container.Config{
 		Image: imageTags[0],
 	}
-	containerID, err := createContainer(ctx, cli, config, strings.ToLower(t.Name()+"-"+uuid.NewString()[:4]))
+	containerID, err := createContainer(ctx, cli, config, nil, strings.ToLower(t.Name()+"-"+uuid.NewString()[:4]))
 	require.NoError(t, err)
 	t.Cleanup(func() { cleanupContainer(context.Background(), cli, containerID) })
 	require.NoError(t, startContainer(cli, ctx, containerID))
@@ -51,7 +51,7 @@ func TestSLBDockerCreateFailedBadImageName(t *testing.T) {
 			"5001":                    struct{}{},
 		},
 	}
-	id, err := createContainer(context.Background(), cli, config, strings.ToLower(t.Name()))
+	id, err := createContainer(context.Background(), cli, config, nil, strings.ToLower(t.Name()))
 	t.Cleanup(func() { cleanupContainer(context.Background(), cli, id) })
 	require.Error(t, err)
 	require.Empty(t, id)

--- a/tests/integration/random_test.go
+++ b/tests/integration/random_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRandomSanity(t *testing.T) {
-	ctx, _, slbContainerID, backendIDs := setupSlbWithBackends(t, 4)
+	ctx, _, slbContainerID, backendIDs, certDir := setupSlbWithBackends(t, 4)
 	slbIp, err := getContainerIP(slbContainerID)
 	require.NoError(t, err)
 	// get backend ids to ips
@@ -32,7 +32,7 @@ func TestRandomSanity(t *testing.T) {
 		s := &api.Server{Address: ip}
 		config.Endpoints = append(config.Endpoints, s)
 	}
-	apiClient, err := newApiClient(slbIp, apiService.DefaultApiPort)
+	apiClient, err := newApiClient(certDir, slbIp, apiService.DefaultApiPort)
 	require.NoError(t, err)
 	_, err = apiClient.Configure(ctx, config)
 	require.NoError(t, err)

--- a/tests/integration/round_robin_test.go
+++ b/tests/integration/round_robin_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRoundRobinSanity(t *testing.T) {
-	ctx, _, slbContainerID, backendIDs := setupSlbWithBackends(t, 4)
+	ctx, _, slbContainerID, backendIDs, certDir := setupSlbWithBackends(t, 4)
 	slbIp, err := getContainerIP(slbContainerID)
 	require.NoError(t, err)
 	// get backend ids to ips
@@ -31,7 +31,7 @@ func TestRoundRobinSanity(t *testing.T) {
 		s := &api.Server{Address: ip}
 		config.Endpoints = append(config.Endpoints, s)
 	}
-	apiClient, err := newApiClient(slbIp, apiService.DefaultApiPort)
+	apiClient, err := newApiClient(certDir, slbIp, apiService.DefaultApiPort)
 	require.NoError(t, err)
 	_, err = apiClient.Configure(ctx, config)
 	require.NoError(t, err)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -38,7 +38,8 @@ func setup(t *testing.T, name string) (context.Context, *client.Client, string) 
 			backendListenPort:  struct{}{},
 		},
 	}
-	containerID, err := createAndStartContainer(ctx, cli, config, strings.ToLower(t.Name())+"-"+strings.ToLower(name))
+	containerName := strings.ToLower(t.Name()) + "-" + strings.ToLower(name)
+	containerID, err := createContainer(ctx, cli, config, containerName)
 	t.Cleanup(func() {
 		o, _ := getContainerLogs(ctx, cli, containerID)
 		t.Log(o)
@@ -46,6 +47,7 @@ func setup(t *testing.T, name string) (context.Context, *client.Client, string) 
 		cleanupContainer(context.Background(), cli, containerID)
 	})
 	require.NoError(t, err)
+	require.NoError(t, startContainer(cli, ctx, containerID))
 
 	return ctx, cli, containerID
 }
@@ -69,7 +71,7 @@ func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *clie
 				backendListenPort:         struct{}{},
 			},
 		}
-		backendContainerID, err := createAndStartContainer(ctx, cli, config, strings.ToLower(t.Name())+"-"+"backend-"+uuid.NewString()[:4])
+		backendContainerID, err := createContainer(ctx, cli, config, strings.ToLower(t.Name())+"-"+"backend-"+uuid.NewString()[:4])
 		t.Cleanup(func() {
 			stopContainer(context.Background(), cli, backendContainerID)
 			cleanupContainer(context.Background(), cli, backendContainerID)
@@ -77,6 +79,7 @@ func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *clie
 		require.NoError(t, err)
 		// required is the shortened id here as the backend provides the full id.
 		backendContainers = append(backendContainers, backendContainerID[:11])
+		require.NoError(t, startContainer(cli, ctx, backendContainerID))
 	}
 	return ctx, cli, containerID, backendContainers
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -7,16 +7,46 @@ import (
 	api "balance/gen"
 	apiService "balance/services/api_service"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
+)
+
+func fileNameFromPath(p string) string {
+	_, fileName := path.Split(p)
+	return fileName
+}
+
+var (
+	certsDirLocalPath         = "../../tmp/certs/"
+	clientCertFileName        = "client-cert.pem"
+	clientKeyFileName         = "client-key.pem"
+	caCertFileName     string = fileNameFromPath(apiService.DefaultCAPath)
+	serverCertFileName string = fileNameFromPath(apiService.DefaultServiceCertPath)
+	serverKeyFileName  string = fileNameFromPath(apiService.DefaultServiceKeyPath)
+	caKeyFileName             = "ca-key.pem"
 )
 
 const (
@@ -24,27 +54,96 @@ const (
 	backendListenPort = "8080"
 )
 
-func newApiClient(serverAddress string, port string) (api.BalanceClient, error) {
-	conn, err := grpc.NewClient(serverAddress+":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func newApiClient(certDir string, serverAddress string, port string) (api.BalanceClient, error) {
+	creds, err := getClientTlsCreds(certDir)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := grpc.NewClient(serverAddress+":"+port, grpc.WithTransportCredentials(creds))
 	return api.NewBalanceClient(conn), err
 }
 
-func setup(t *testing.T, name string) (context.Context, *client.Client, string) {
+func getClientTlsCreds(certDir string) (credentials.TransportCredentials, error) {
+	// Load the CA certificate
+	caCert, err := os.ReadFile(certDir + caCertFileName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read CA certificate maybe you need to generate them (make certs): %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("Failed to append CA certificate")
+	}
+
+	// Load the client's certificate and private key
+	clientCert, err := tls.LoadX509KeyPair(certDir+clientCertFileName, certDir+clientKeyFileName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load client certificate and key: %v", err)
+	}
+
+	// Configure TLS for the gRPC client
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+	}
+	creds := credentials.NewTLS(tlsConfig)
+	return creds, nil
+}
+
+func setup(t *testing.T) (context.Context, *client.Client, string, string) {
 	ctx := context.Background()
 
 	cli, err := createDockerClient()
 	require.NoError(t, err)
 
 	imageTags := []string{slbImageRepo + imgVersion}
+	testInstanceName := testNameWithUUID(t)
+	certDirAbsPath, err := filepath.Abs(certsDirLocalPath + testInstanceName)
+	require.NoError(t, err)
+	certDir := certDirAbsPath + "/"
+	require.NoError(t, os.MkdirAll(certDir, 0755))
+	t.Cleanup(func() { os.RemoveAll(certDir) })
+
 	config := &container.Config{
 		Image: imageTags[0],
 		ExposedPorts: nat.PortSet{
 			nat.Port(HostPort): struct{}{},
 			backendListenPort:  struct{}{},
 		},
+		// Due to the certificates needing to be created with the container id which is
+		// obtainable only after starting the container a wait script is needed to wait for the certificates
+		// before running balance
+		Entrypoint: []string{"/bin/sh", "-c", fmt.Sprintf(
+			"for file in %s %s %s; do while [ ! -f $file ]; do sleep 0.001 && ls %s; done; done; echo 'certificates created'; %s",
+			apiService.DefaultServiceKeyPath,
+			apiService.DefaultServiceKeyPath,
+			apiService.DefaultCAPath,
+			apiService.DefaultCertsDirectory,
+			"exec ./balance", // the command is executed with exec to disconnect from sh
+		)},
 	}
-	containerName := strings.ToLower(t.Name()) + "-" + strings.ToLower(name)
-	containerID, err := createContainer(ctx, cli, config, containerName)
+
+	hostConfig := &container.HostConfig{
+		PortBindings: nat.PortMap{
+			apiService.DefaultApiPort + "/tcp": []nat.PortBinding{
+				{
+					HostIP:   "0.0.0.0",
+					HostPort: HostPort,
+				},
+			},
+			backendListenPort + "/tcp": []nat.PortBinding{
+				{
+					HostIP:   "0.0.0.0",
+					HostPort: backendListenPort,
+				},
+			},
+		},
+		Mounts: []mount.Mount{{
+			Type:   mount.TypeBind,
+			Source: certDir,
+			Target: apiService.DefaultCertsDirectory,
+		}},
+	}
+	containerID, err := createContainer(ctx, cli, config, hostConfig, strings.ToLower(testInstanceName)+"-"+"slb")
 	t.Cleanup(func() {
 		o, _ := getContainerLogs(ctx, cli, containerID)
 		t.Log(o)
@@ -52,14 +151,20 @@ func setup(t *testing.T, name string) (context.Context, *client.Client, string) 
 		cleanupContainer(context.Background(), cli, containerID)
 	})
 	require.NoError(t, err)
+
+	require.NoError(t, startContainer(cli, ctx, containerID))
+	setupMtls(t, containerID, certDir)
+
+	// stop and start container to make balance start without delay, waiting for files
+	require.NoError(t, stopContainer(ctx, cli, containerID))
 	require.NoError(t, startContainer(cli, ctx, containerID))
 
-	return ctx, cli, containerID
+	return ctx, cli, containerID, certDir
 }
 
-func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *client.Client, string, []string) {
+func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *client.Client, string, []string, string) {
 	// setup slb
-	ctx, cli, containerID := setup(t, "slb"+"-"+uuid.NewString()[:4])
+	ctx, cli, containerID, certDir := setup(t)
 	// setup backends
 	backendContainers := make([]string, 0)
 	for i := 0; i < numBackends; i++ {
@@ -76,7 +181,22 @@ func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *clie
 				backendListenPort:         struct{}{},
 			},
 		}
-		backendContainerID, err := createContainer(ctx, cli, config, strings.ToLower(t.Name())+"-"+"backend-"+uuid.NewString()[:4])
+		hostConfig := &container.HostConfig{
+			PortBindings: nat.PortMap{
+				backendListenPort + "/tcp": []nat.PortBinding{
+					{
+						HostIP:   "0.0.0.0",
+						HostPort: backendListenPort,
+					},
+				},
+			},
+			Mounts: []mount.Mount{{
+				Type:   mount.TypeBind,
+				Source: certDir,
+				Target: apiService.DefaultCertsDirectory,
+			}},
+		}
+		backendContainerID, err := createContainer(ctx, cli, config, hostConfig, strings.ToLower(testNameWithUUID(t))+"-"+"backend-")
 		t.Cleanup(func() {
 			stopContainer(context.Background(), cli, backendContainerID)
 			cleanupContainer(context.Background(), cli, backendContainerID)
@@ -86,5 +206,186 @@ func setupSlbWithBackends(t *testing.T, numBackends int) (context.Context, *clie
 		backendContainers = append(backendContainers, backendContainerID[:11])
 		require.NoError(t, startContainer(cli, ctx, backendContainerID))
 	}
-	return ctx, cli, containerID, backendContainers
+	return ctx, cli, containerID, backendContainers, certDir
+}
+
+func setupMtls(t *testing.T, containerID string, localCertsDir string) {
+	// get local ips
+	outboundIP, err := getOutBoundIP()
+	require.NoError(t, err)
+	localIP, err := getLocalIP()
+	require.NoError(t, err)
+
+	var ip string
+	require.Eventually(t, func() bool {
+		ip, _ = getContainerIP(containerID)
+		return ip != ""
+	}, time.Second*10, time.Millisecond*30)
+
+	require.NotEmpty(t, ip)
+	require.NoError(t, err)
+
+	// Create the CA
+
+	// Both the server and the client must be in the SANs
+	CN := "balance"
+	dnsNames := []string{"localhost", CN}
+
+	caCert, caKey, caCertPEM, caKeyPEM, err := generateCA(CN, []net.IP{}, dnsNames)
+	require.NoError(t, err)
+
+	// Generate server and client certificates signed by the CA
+	serverCertPEM, serverKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{net.ParseIP(ip)}, dnsNames)
+	require.NoError(t, err)
+	clientCertPEM, clientKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{localIP, outboundIP}, dnsNames)
+	require.NoError(t, err)
+
+	// Save Certs
+	type certFile struct {
+		localpath string
+		content   []byte
+		mode      os.FileMode
+	}
+	files := []certFile{
+		// ca
+		{localCertsDir + caCertFileName, caCertPEM, 0644},
+		{localCertsDir + caKeyFileName, caKeyPEM, 0600},
+		// server
+		{localCertsDir + serverCertFileName, serverCertPEM, 0644},
+		{localCertsDir + serverKeyFileName, serverKeyPEM, 0600},
+		// client
+		{localCertsDir + clientCertFileName, clientCertPEM, 0644},
+		{localCertsDir + clientKeyFileName, clientKeyPEM, 0600},
+	}
+	for _, file := range files {
+		require.NoError(t, os.WriteFile(file.localpath, file.content, file.mode))
+	}
+}
+
+func generateCA(host string, ipAddresses []net.IP, dnsNames []string) (*x509.Certificate, *ecdsa.PrivateKey, []byte, []byte, error) {
+	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{host},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour), // Valid for 10 years
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		IPAddresses:           ipAddresses,
+		DNSNames:              dnsNames,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caPriv.PublicKey, caPriv)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+	ecPriv, err := x509.MarshalECPrivateKey(caPriv)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	caKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecPriv})
+
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	return caCert, caPriv, caCertPEM, caKeyPEM, nil
+}
+
+// Helper function to generate a certificate and private key with SANs
+func generateCertificate(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, host string, ipAddresses []net.IP, dnsNames []string) ([]byte, []byte, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour) // Certificate valid for one year
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   host,
+			Organization: []string{host},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           ipAddresses,
+		DNSNames:              dnsNames,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	ecPriv, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecPriv})
+
+	return certPEM, keyPEM, nil
+}
+
+func getLocalIP() (net.IP, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue // Skip down or loopback interfaces
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if ok && !ipNet.IP.IsLoopback() && ipNet.IP.To4() != nil {
+				return ipNet.IP, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no valid local IP address found")
+}
+
+func getOutBoundIP() (net.IP, error) {
+	// Create a UDP connection to an external address (Google's public DNS)
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// Get the local address of the connection and extract the IP
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP, nil
+}
+
+func testNameWithUUID(t *testing.T) string {
+	return t.Name() + "-" + uuid.NewString()[:4]
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -19,6 +19,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	HostPort          = apiService.DefaultApiPort
+	backendListenPort = "8080"
+)
+
 func newApiClient(serverAddress string, port string) (api.BalanceClient, error) {
 	conn, err := grpc.NewClient(serverAddress+":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	return api.NewBalanceClient(conn), err


### PR DESCRIPTION
This introduces mTLS to the api Service.

Only mTLS authentication will be allowed for using the API.

In order to achieve this, the machine the balance server runs on needs to have the mTLS compliant pls certificates preinstalled prior to running balance (CA, service-key.pem and service-cert.pem stored in the default path /etc/certs.).

- Integration tests now utilize mTLS.

#29  