### PR TITLE
.github/workflows/master.yml:run names

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,5 @@
 name: Tests
+run-name: "${{ github.workflow }}: ${{ github.event.pull_request.title || github.actor }} : ${{ github.event_name }}"
 
 on:
   push:


### PR DESCRIPTION
Add names to runs as they are currently not possible to differentiate and meaningless.