### PR TITLE
internal/apiService/service.go:fix Configuration returns wrong strategy

### DIFF
--- a/internal/apiService/service.go
+++ b/internal/apiService/service.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -50,10 +49,10 @@ func (b *balanceServer) Configuration(ctx context.Context, _ *emptypb.Empty) (*a
 	}
 	strategy := api.SelectorStrategy_SELECTOR_STRATEGY_UNSPECIFIED
 	t := reflect.TypeOf(b.selector)
-	if strings.Contains(api.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN.String(), t.Name()) {
+	if reflect.TypeOf(&roundRobin.RoundRobin{}) == t {
 		strategy = api.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN
 	}
-	if strings.Contains(api.SelectorStrategy_SELECTOR_STRATEGY_RANDOM.String(), t.Name()) {
+	if reflect.TypeOf(&randomSelector.Random{}) == t {
 		strategy = api.SelectorStrategy_SELECTOR_STRATEGY_RANDOM
 	}
 	if strategy == api.SelectorStrategy_SELECTOR_STRATEGY_UNSPECIFIED {

--- a/internal/apiService/service_test.go
+++ b/internal/apiService/service_test.go
@@ -39,6 +39,7 @@ func TestConfigurationWithSLBShouldReturnConfig(t *testing.T) {
 		ListenAddress: localAddress,
 		ListenPort:    defaultPort,
 		Endpoints:     []*gen.Server{{Address: localAddress}},
+		Strategy:      gen.SelectorStrategy_SELECTOR_STRATEGY_RANDOM,
 	}
 	_, err := balanceServer.Configure(context.Background(), slbConfig)
 	require.NoError(t, err)
@@ -47,6 +48,7 @@ func TestConfigurationWithSLBShouldReturnConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, slbConfig.ListenAddress, config.ListenAddress)
 	require.Equal(t, slbConfig.ListenPort, config.ListenPort)
+	require.Exactly(t, gen.SelectorStrategy_SELECTOR_STRATEGY_RANDOM, config.Strategy)
 }
 
 func TestConfigureShouldSetNewConfig(t *testing.T) {


### PR DESCRIPTION
The type check to return the correct stragety was not working, resulting in Round Robin always being returned as strategy.