### PR TITLE
slb/slb_test.go:stabilize happy flow

### DIFF
--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -11,7 +11,7 @@ func RandomAddress() string {
 }
 
 func RandomPort() string {
-	return fmt.Sprint(rand.Intn(5000 - 1024 + 1))
+	return fmt.Sprint(1024 + rand.Intn(50000))
 }
 
 func newServer(addr string) *http.Server {

--- a/slb/slb_test.go
+++ b/slb/slb_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -127,7 +128,8 @@ func TestSLB(t *testing.T) {
 					runErr <- slb.Run()
 					require.NoError(t, err)
 				}(t, slb)
-
+				// wait for the slb to init properly
+				<-time.After(time.Millisecond * 250)
 				// send request to SLB
 				targetUrl := "http://" + string(listenAddress) + ":" + listenPort + "/food"
 				slog.Info("sending request to " + targetUrl)


### PR DESCRIPTION
Although locally this barely ever occurred, this test was flaky when running in the CI or a containerized environment, erroring out on a connection error, due to permission denied.
This occurred as RandomPort was providing privileged ports sub 1024.