### PR TITLE
tests/deployment/docker/docker_harness.go:container start err

### DIFF
--- a/tests/deployment/docker/docker_harness.go
+++ b/tests/deployment/docker/docker_harness.go
@@ -71,7 +71,7 @@ func StartContainer(ctx context.Context, client *client.Client, containerID stri
 	running := make(chan bool)
 	go waitRunning(running)
 	if running := <-running; !running {
-		return fmt.Errorf("")
+		return fmt.Errorf("container did not start in time")
 	}
 
 	return nil


### PR DESCRIPTION
container start now errors out correctly with an error message when not running