### PR TITLE
Roy/decoulpe slb and api service

### DIFF
--- a/internal/balanceService/service.go
+++ b/internal/balanceService/service.go
@@ -1,0 +1,141 @@
+//go:generate protoc --proto_path=../../api --go_out=.. --go-grpc_out=.. balance.proto
+package balanceService
+
+import (
+	api "balance/gen"
+	randomSelector "balance/internal/selectors/random"
+	"balance/internal/selectors/roundRobin"
+	"balance/slb"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const DefaultAddress = "0.0.0.0"
+const DefaultPort = "8080"
+
+var ErrNotConfigured = fmt.Errorf("slb not configured correctly")
+
+type BalanceServer struct {
+	api.UnimplementedBalanceServer
+	selector slb.Selector
+	slb      *slb.Slb
+}
+
+func (b *BalanceServer) Configuration(ctx context.Context, _ *emptypb.Empty) (*api.Config, error) {
+	if b.slb == nil {
+		return nil, ErrNotConfigured
+	}
+	cfg := b.slb.Configuration()
+	endpoints := []*api.Server{}
+	for _, endpoint := range cfg.Endpoints {
+		endpoints = append(endpoints, &api.Server{
+			Address: endpoint.Addr,
+		})
+	}
+	strategy := api.SelectorStrategy_SELECTOR_STRATEGY_UNSPECIFIED
+	t := reflect.TypeOf(b.selector)
+	if reflect.TypeOf(&roundRobin.RoundRobin{}) == t {
+		strategy = api.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN
+	}
+	if reflect.TypeOf(&randomSelector.Random{}) == t {
+		strategy = api.SelectorStrategy_SELECTOR_STRATEGY_RANDOM
+	}
+	if strategy == api.SelectorStrategy_SELECTOR_STRATEGY_UNSPECIFIED {
+		slog.Warn("No strategy configured")
+	}
+
+	return &api.Config{
+		Endpoints:     endpoints,
+		ListenPort:    cfg.ListenPort,
+		ListenAddress: cfg.ListenAddress,
+		HandlePostfix: cfg.HandlePostfix,
+		Strategy:      strategy,
+	}, nil
+}
+
+func (b *BalanceServer) Configure(ctx context.Context, config *api.Config) (*emptypb.Empty, error) {
+	if b.slb != nil {
+		slog.Info(fmt.Sprintf("Stopping server with previous configuration %v", b.slb.Configuration()))
+		if err := b.slb.Stop(); err != nil {
+			return &emptypb.Empty{}, err
+		}
+	}
+
+	slog.Info(fmt.Sprintf("Setting new configuration: %v", config))
+	newConfig := slb.Config{
+		Endpoints:     make([]*http.Server, 0),
+		ListenAddress: config.ListenAddress,
+		ListenPort:    config.ListenPort,
+		HandlePostfix: config.HandlePostfix,
+	}
+	for _, server := range config.Endpoints {
+		newConfig.Endpoints = append(newConfig.Endpoints, &http.Server{Addr: server.Address})
+	}
+
+	switch config.Strategy {
+	case api.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN:
+		b.selector = roundRobin.New()
+	case api.SelectorStrategy_SELECTOR_STRATEGY_RANDOM:
+		b.selector = randomSelector.New()
+	default:
+		b.selector = roundRobin.New()
+	}
+
+	slb, err := slb.New(newConfig, b.selector)
+	if err != nil {
+		return &emptypb.Empty{}, err
+	}
+	b.slb = slb
+	return &emptypb.Empty{}, nil
+}
+
+func (b *BalanceServer) Run(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	if b.slb == nil {
+		return nil, ErrNotConfigured
+	}
+	go b.slb.Run()
+	slog.Info("Running ")
+	return req, nil
+}
+
+func (b *BalanceServer) Stop(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	if b.slb == nil {
+		return nil, ErrNotConfigured
+	}
+	return req, b.slb.Stop()
+}
+
+func (b *BalanceServer) Add(ctx context.Context, server *api.Server) (*emptypb.Empty, error) {
+	if b.selector == nil {
+		return nil, ErrNotConfigured
+	}
+	s := &http.Server{Addr: server.Address}
+	return &emptypb.Empty{}, b.selector.Add(s)
+}
+
+func (b *BalanceServer) Remove(ctx context.Context, server *api.Server) (*emptypb.Empty, error) {
+	if b.selector == nil {
+		return nil, ErrNotConfigured
+	}
+	s := &http.Server{Addr: server.Address}
+	return &emptypb.Empty{}, b.selector.Remove(s)
+}
+
+func NewBalanceService() *BalanceServer {
+	slbServer := &BalanceServer{}
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	// Configure with default values
+	slbServer.Configure(ctx, &api.Config{
+		Strategy:      api.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN,
+		ListenAddress: DefaultAddress,
+		ListenPort:    DefaultPort,
+		HandlePostfix: slb.DefaultHandlePostfix,
+	})
+	return slbServer
+}

--- a/internal/balanceService/service_test.go
+++ b/internal/balanceService/service_test.go
@@ -1,0 +1,157 @@
+package balanceService
+
+import (
+	"balance/gen"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const (
+	localAddress = "127.0.0.1"
+	defaultPort  = "8080"
+	serverPort   = ":8081"
+)
+
+func setupServer() (*grpc.Server, *BalanceServer) {
+	grpcServer := grpc.NewServer()
+	balanceServer := &BalanceServer{}
+	gen.RegisterBalanceServer(grpcServer, balanceServer)
+	return grpcServer, balanceServer
+}
+
+func TestConfigurationNoSLBShouldReturnError(t *testing.T) {
+	_, balanceServer := setupServer()
+
+	ctx := context.Background()
+	_, err := balanceServer.Configuration(ctx, &emptypb.Empty{})
+
+	require.Error(t, err)
+	require.Equal(t, ErrNotConfigured, err)
+}
+
+func TestConfigurationWithSLBShouldReturnConfig(t *testing.T) {
+	_, balanceServer := setupServer()
+	slbConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    defaultPort,
+		Endpoints:     []*gen.Server{{Address: localAddress}},
+		Strategy:      gen.SelectorStrategy_SELECTOR_STRATEGY_RANDOM,
+	}
+	_, err := balanceServer.Configure(context.Background(), slbConfig)
+	require.NoError(t, err)
+	config, err := balanceServer.Configuration(context.Background(), &emptypb.Empty{})
+
+	require.NoError(t, err)
+	require.Equal(t, slbConfig.ListenAddress, config.ListenAddress)
+	require.Equal(t, slbConfig.ListenPort, config.ListenPort)
+	require.Exactly(t, gen.SelectorStrategy_SELECTOR_STRATEGY_RANDOM, config.Strategy)
+}
+
+func TestConfigureShouldSetNewConfig(t *testing.T) {
+	_, balanceServer := setupServer()
+	newConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    "9090",
+		Endpoints:     []*gen.Server{{Address: localAddress}},
+	}
+
+	_, err := balanceServer.Configure(context.Background(), newConfig)
+	require.NoError(t, err)
+}
+
+func TestRunNoSLBShouldReturnError(t *testing.T) {
+	_, balanceServer := setupServer()
+
+	ctx := context.Background()
+	_, err := balanceServer.Run(ctx, &emptypb.Empty{})
+
+	require.Error(t, err)
+	require.Equal(t, ErrNotConfigured, err)
+}
+
+func TestRunWithSLBShouldRunSuccessfully(t *testing.T) {
+	_, balanceServer := setupServer()
+	slbConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    defaultPort,
+		Endpoints:     []*gen.Server{{Address: localAddress}},
+	}
+
+	balanceServer.Configure(context.Background(), slbConfig)
+	_, err := balanceServer.Run(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+}
+
+func TestStopNoSLBShouldReturnError(t *testing.T) {
+	_, balanceServer := setupServer()
+
+	ctx := context.Background()
+	_, err := balanceServer.Stop(ctx, &emptypb.Empty{})
+
+	require.Error(t, err)
+	require.Equal(t, ErrNotConfigured, err)
+}
+
+func TestStopWithSLBShouldStopSuccessfully(t *testing.T) {
+	_, balanceServer := setupServer()
+	slbConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    defaultPort,
+		Endpoints:     []*gen.Server{{Address: localAddress}},
+	}
+
+	balanceServer.Configure(context.Background(), slbConfig)
+	_, err := balanceServer.Stop(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+}
+
+func TestAddNoSelectorShouldReturnError(t *testing.T) {
+	_, balanceServer := setupServer()
+
+	ctx := context.Background()
+	_, err := balanceServer.Add(ctx, &gen.Server{Address: localAddress + serverPort})
+
+	require.Error(t, err)
+	require.Equal(t, ErrNotConfigured, err)
+}
+
+func TestAddWithSelectorShouldAddServer(t *testing.T) {
+	_, balanceServer := setupServer()
+	slbConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    defaultPort,
+		Strategy:      gen.SelectorStrategy_SELECTOR_STRATEGY_ROUND_ROBIN,
+	}
+
+	balanceServer.Configure(context.Background(), slbConfig)
+	_, err := balanceServer.Add(context.Background(), &gen.Server{Address: localAddress + serverPort})
+	require.NoError(t, err)
+}
+
+func TestRemoveNoSelectorShouldReturnError(t *testing.T) {
+	_, balanceServer := setupServer()
+
+	ctx := context.Background()
+	_, err := balanceServer.Remove(ctx, &gen.Server{Address: localAddress + serverPort})
+
+	require.Error(t, err)
+	require.Equal(t, ErrNotConfigured, err)
+}
+
+func TestRemoveWithSelectorShouldRemoveServer(t *testing.T) {
+	_, balanceServer := setupServer()
+	slbConfig := &gen.Config{
+		ListenAddress: localAddress,
+		ListenPort:    defaultPort,
+		Strategy:      gen.SelectorStrategy_SELECTOR_STRATEGY_RANDOM,
+	}
+
+	balanceServer.Configure(context.Background(), slbConfig)
+	balanceServer.Add(context.Background(), &gen.Server{Address: localAddress + serverPort})
+	_, err := balanceServer.Remove(context.Background(), &gen.Server{Address: localAddress + serverPort})
+	require.NoError(t, err)
+}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -64,11 +64,10 @@ func setupMtls(t require.TestingT, outboundIP net.IP, localIP net.IP, ip string,
 	require.NoError(t, err)
 
 	// Generate server and client certificates signed by the CA
-	serverCertPEM, serverKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{net.ParseIP(ip)}, dnsNames)
+	serverCertPEM, serverKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{net.ParseIP(ip), net.ParseIP(apiService.DefaultAddress)}, dnsNames)
 	require.NoError(t, err)
-	clientCertPEM, clientKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{net.IP(localIP), outboundIP}, dnsNames)
+	clientCertPEM, clientKeyPEM, err := generateCertificate(caCert, caKey, CN, []net.IP{net.IP(localIP), net.ParseIP(apiService.DefaultAddress), outboundIP}, dnsNames)
 	require.NoError(t, err)
-
 	// Save Certs
 	type certFile struct {
 		localpath string


### PR DESCRIPTION
This extracts the balanceService to an independent service from the api
service.

The balanceServer(service) has its own grpc server, whereas the apiServer(service) is a
client to the balanceServer. This allows for better decoupling of the
two.

The api service will be the only publicly exposed grpc service.